### PR TITLE
chore: pin exact dependency versions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.mjs",
   "license": "UNLICENSED",
   "dependencies": {
-    "semver": "^7.7.4"
+    "semver": "7.7.4"
   },
   "repository": {
     "type": "git",
@@ -16,21 +16,21 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
-    "@stylistic/eslint-plugin": "^5.10.0",
-    "eslint": "^10.1.0",
-    "eslint-config-prettier": "^10.1.8",
-    "eslint-import-resolver-typescript": "^4.4.4",
-    "eslint-plugin-import-x": "^4.16.2",
-    "eslint-plugin-prettier": "^5.5.5",
-    "eslint-plugin-unused-imports": "^4.4.1",
-    "generate-changelog": "^1.8.0",
-    "globals": "^17.4.0",
-    "prettier": "^3.8.1",
-    "typescript": "^6.0.2",
-    "typescript-eslint": "^8.58.0",
-    "vite": "^8.0.16",
-    "vitest": "^4.1.5"
+    "@eslint/js": "10.0.1",
+    "@stylistic/eslint-plugin": "5.10.0",
+    "eslint": "10.1.0",
+    "eslint-config-prettier": "10.1.8",
+    "eslint-import-resolver-typescript": "4.4.4",
+    "eslint-plugin-import-x": "4.16.2",
+    "eslint-plugin-prettier": "5.5.5",
+    "eslint-plugin-unused-imports": "4.4.1",
+    "generate-changelog": "1.8.0",
+    "globals": "17.4.0",
+    "prettier": "3.8.1",
+    "typescript": "6.0.2",
+    "typescript-eslint": "8.58.0",
+    "vite": "8.0.16",
+    "vitest": "4.1.5"
   },
   "peerDependencies": {
     "@eslint/js": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,53 +9,53 @@ importers:
   .:
     dependencies:
       semver:
-        specifier: ^7.7.4
+        specifier: 7.7.4
         version: 7.7.4
     devDependencies:
       '@eslint/js':
-        specifier: ^10.0.1
+        specifier: 10.0.1
         version: 10.0.1(eslint@10.1.0)
       '@stylistic/eslint-plugin':
-        specifier: ^5.10.0
+        specifier: 5.10.0
         version: 5.10.0(eslint@10.1.0)
       eslint:
-        specifier: ^10.1.0
+        specifier: 10.1.0
         version: 10.1.0
       eslint-config-prettier:
-        specifier: ^10.1.8
+        specifier: 10.1.8
         version: 10.1.8(eslint@10.1.0)
       eslint-import-resolver-typescript:
-        specifier: ^4.4.4
+        specifier: 4.4.4
         version: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.58.0(eslint@10.1.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@10.1.0))(eslint-plugin-import@2.29.1)(eslint@10.1.0)
       eslint-plugin-import-x:
-        specifier: ^4.16.2
+        specifier: 4.16.2
         version: 4.16.2(@typescript-eslint/utils@8.58.0(eslint@10.1.0)(typescript@6.0.2))(eslint-import-resolver-node@0.3.9)(eslint@10.1.0)
       eslint-plugin-prettier:
-        specifier: ^5.5.5
+        specifier: 5.5.5
         version: 5.5.5(@types/eslint@8.56.10)(eslint-config-prettier@10.1.8(eslint@10.1.0))(eslint@10.1.0)(prettier@3.8.1)
       eslint-plugin-unused-imports:
-        specifier: ^4.4.1
+        specifier: 4.4.1
         version: 4.4.1(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)(typescript@6.0.2))(eslint@10.1.0)
       generate-changelog:
-        specifier: ^1.8.0
+        specifier: 1.8.0
         version: 1.8.0
       globals:
-        specifier: ^17.4.0
+        specifier: 17.4.0
         version: 17.4.0
       prettier:
-        specifier: ^3.8.1
+        specifier: 3.8.1
         version: 3.8.1
       typescript:
-        specifier: ^6.0.2
+        specifier: 6.0.2
         version: 6.0.2
       typescript-eslint:
-        specifier: ^8.58.0
+        specifier: 8.58.0
         version: 8.58.0(eslint@10.1.0)(typescript@6.0.2)
       vite:
-        specifier: ^8.0.16
+        specifier: 8.0.16
         version: 8.0.16(esbuild@0.27.7)
       vitest:
-        specifier: ^4.1.5
+        specifier: 4.1.5
         version: 4.1.5(vite@8.0.16(esbuild@0.27.7))
 
 packages:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the `^` range prefixes from `dependencies` and `devDependencies` in `package.json`, pinning each package to the exact version already resolved in `pnpm-lock.yaml`. The lockfile `specifier` fields are updated to match; resolved versions are unchanged, so the installed dependency tree is identical.

`peerDependencies` are intentionally left as ranges — they declare which versions consuming projects may use, and pinning them would force every consumer onto a single exact version.

## Changes

- `package.json`: `semver` and all 15 devDependencies pinned to exact versions (e.g. `^8.0.16` → `8.0.16`)
- `pnpm-lock.yaml`: importer specifiers updated to match; no resolution changes

## Testing

- `pnpm install --frozen-lockfile` passes ("Lockfile is up to date"), confirming package.json and the lockfile are in sync
- `pnpm test` passes (6/6 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-579d2bd5-66ee-4a05-8a02-cebf3bdfa0ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-579d2bd5-66ee-4a05-8a02-cebf3bdfa0ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

